### PR TITLE
Fix: update a11y helpers (fixes #9)

### DIFF
--- a/js/adapt-hint.js
+++ b/js/adapt-hint.js
@@ -1,6 +1,7 @@
 define([
-  'core/js/adapt'
-], function (Adapt) {
+  'core/js/adapt',
+  'core/js/reactHelpers'
+], function (Adapt, compile) {
 
   const HintPopupView = Backbone.View.extend({
 

--- a/js/adapt-hint.js
+++ b/js/adapt-hint.js
@@ -1,7 +1,6 @@
 define([
-  'core/js/adapt',
-  'core/js/reactHelpers'
-], function (Adapt, compile) {
+  'core/js/adapt'
+], function (Adapt) {
 
   const HintPopupView = Backbone.View.extend({
 

--- a/templates/hint.hbs
+++ b/templates/hint.hbs
@@ -23,7 +23,7 @@
         {{#if body}}
         <div class="hint__item-body">
           <div class="hint__item-body-inner">
-            {{{compile_a11y_text body}}}
+            {{{compile body}}}
           </div>
         </div>
         {{/if}}

--- a/templates/hint.hbs
+++ b/templates/hint.hbs
@@ -15,7 +15,7 @@
         {{#if title}}
         <div class="hint__item-title{{#if body}} has-margin{{/if}}">
           <div class="hint__item-title-inner">
-            {{{title}}}
+            {{{compile title}}}
           </div>
         </div>
         {{/if}}

--- a/templates/hintPopup.hbs
+++ b/templates/hintPopup.hbs
@@ -17,7 +17,7 @@
       {{#if body}}
       <div class="hint-popup__item-body">
         <div class="hint-popup__item-body-inner">
-          {{{a11y_text body}}}
+          {{{compile body}}}
         </div>
       </div>
       {{/if}}

--- a/templates/hintPopup.hbs
+++ b/templates/hintPopup.hbs
@@ -9,7 +9,7 @@
       {{#if title}}
       <div class="hint-popup__item-title{{#if body}} has-margin{{/if}}">
         <div class="hint-popup__item-title-inner">
-          {{{title}}}
+          {{{compile title}}}
         </div>
       </div>
       {{/if}}


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-hint/issues/9

- replace deprecated `a11y_text`
- support [a11y_alt_text](https://github.com/adaptlearning/adapt-contrib-core/commit/a92c7ffdb431bdf126e080c009b3b9c324642755) helper.

## PR Test
Apply the following config to any component.
```
        "_hint": {
            "_items": [
                {
                    "title": "Adapt Hint {{a11y_alt_text '$5bn' 'five billion dollars'}}",
                    "body": "An extension {{a11y_alt_text '$5bn' 'five billion dollars'}} that adds a small, clickable icon to a component that displays additional information."
                },
                {
                    "title": "Additional",
                    "body": "Information"
                }
            ],
            "_isNotifyPopup": true
        }
```
In your course, select the hint button to trigger the popup. The `a11y_alt_text` helper syntax shouldn't be visible within the popup display text and instead should just display '$5bn'. 

Using the browser devtools, inspect '$5bn' and the helper should have split out the on screen text and a11y text e.g.
`<span aria-hidden="true">$5bn</span><span class="aria-label">five billion dollars</span>`

Please test with `"_isNotifyPopup": false` also.