### PR TITLE
New: button text +/ icon support, items removed and a11y enhancements (fixes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The attributes listed below are used in *components.json* to configure **Hint**,
 
 ## Attributes
 
+>**\_isEnabled** (boolean): Turns **Hint** on and off. Acceptable values are `true` and `false`.
+
 >**title** (string): The title displayed in the popup.
 
 >**altTitle** (string): This will be read out by screen readers as an alternative title if no visual **title** is included.
@@ -36,7 +38,7 @@ The attributes listed below are used in *components.json* to configure **Hint**,
 
 >>**text** (string): The text that displays in the `button`.
 
->>**ariaLabel** (string): This will be read out by screen readers as an alternative title if no visual title is included.
+>>**ariaLabel** (string): This will be read out by screen readers as alternative text if no visual button text is included.
 
 ## Accessibility
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ A global **Hint** button `aria-label` can be set within the `_globals._extension
 No known limitations.
 
 ----------------------------
-**Version number:** 3.0.0<br>
-**Framework versions:** 5.5+<br>
 **Author / maintainer:**  Kineo<br>
 **Accessibility support:** WAI AA<br>
 **RTL support:** Yes<br>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 <img src="demo.gif" alt="the hint extension in action" align="right">
 
-**Hint** is a Kineo *presentation extension*.
+**Hint** is an *extension* for the [Adapt framework](https://github.com/adaptlearning/adapt_framework).
 
-The extension adds a small, clickable icon to a component that displays additional information.
+The extension appends a button to any component. On selecting the button, additional content is displayed in a popup. The button can contain either text and/or icon and can be configured per component.
+
+The intended use is a 'hint' for question components, providing additional content to aid answering a question. Or, to provide 'more info' for presentation components. Whether to declutter text heavy content, or, group content of a particular type/theme.
+
+The hint button is displayed between the component display text (header) and the interaction (widget). For components without display text, the button is displayed after the interaction (widget).
 
 ## Installation
 
@@ -18,23 +22,34 @@ The attributes listed below are used in *components.json* to configure **Hint**,
 
 ## Attributes
 
-**_items** (array): Multiple items may be created. Each item represents one element of the hint extension and contains values for **title**, and **body**.
+>**title** (string): The title displayed in the popup.
 
->**title** (string): The title of the particular item.
+>**altTitle** (string): This will be read out by screen readers as an alternative title if no visual **title** is included.
 
->**body** (string): The body text content of the particular item.
+>**body** (string): The body text displayed in the popup.
 
-**_isNotifyPopup** (boolean): When set to true, hint item(s) are displayed using Notify, the core FW functionality that handles popups. The default is false. When false, hint item(s) overlay the component.
+>**\_button** (object): The **Hint** button contains values for **\_iconClass**, **\_alignIconRight**, **text** and **ariaLabel**.
+
+>>**\_iconClass** (string): CSS class name to be applied to the `button` icon. The class must be predefined in one of the Less files with the corresponding icon added as part of a font. See list of available [_vanilla_ icons](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Icons) to choose from. Default is `icon-question`.
+
+>>**\_alignIconright** (boolean): Defines whether the icon is aligned to the left or right of the text (if applicable). Default is `true`, which aligns the icon to the right of the text.
+
+>>**text** (string): The text that displays in the `button`.
+
+>>**ariaLabel** (string): This will be read out by screen readers as an alternative title if no visual title is included.
 
 ## Accessibility
-Please use **_isNotifyPopup** for best accessibility experience.
+
+A global **Hint** button `aria-label` can be set within the `_globals._extensions._hint.openButtonText` object in **course.json** (or Project settings > Globals in the Adapt Authoring Tool). Default is `Open hint`. This will be overridden when setting either **text** or **ariaLabel** on the component's model in *components.json*.
 
 ## Limitations
 
+No known limitations.
+
 ----------------------------
-**Version number:** 3.0.0  
-**Framework versions:** 5.5+  
-**Author / maintainer:**  Kineo  
-**Accessibility support:** Yes  
-**RTL support:** Yes  
-**Cross-platform coverage:** To be confirmed  
+**Version number:** 3.0.0<br>
+**Framework versions:** 5.5+<br>
+**Author / maintainer:**  Kineo<br>
+**Accessibility support:** WAI AA<br>
+**RTL support:** Yes<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera<br>

--- a/bower.json
+++ b/bower.json
@@ -2,12 +2,8 @@
   "name": "adapt-hint",
   "version": "3.0.0",
   "framework": ">=5.5",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/cgkineo/adapt-hint"
-  },
   "homepage": "https://github.com/cgkineo/adapt-hint",
-  "issues": "https://github.com/cgkineo/adapt-hint/issues/",
+  "bugs": "https://github.com/cgkineo/adapt-hint/issues",
   "extension": "hint",
   "displayName": "Hint",
   "description": "An extension that adds a small icon to any component that, when clicked, displays additional information",

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/cgkineo/adapt-hint/issues",
   "extension": "hint",
   "displayName": "Hint",
-  "description": "An extension that adds a button to any component that, when selected, displays additional information in a popup",
+  "description": "An extension that adds a small icon to any component that, when clicked, displays additional information",
   "main": "/js/adapt-hint.js",
   "keywords": [
     "adapt-plugin",

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/cgkineo/adapt-hint/issues",
   "extension": "hint",
   "displayName": "Hint",
-  "description": "An extension that adds a small icon to any component that, when clicked, displays additional information",
+  "description": "An extension that adds a button to any component that, when selected, displays additional information in a popup",
   "main": "/js/adapt-hint.js",
   "keywords": [
     "adapt-plugin",

--- a/example.json
+++ b/example.json
@@ -2,5 +2,18 @@
     "_hint": {
         "title": "Adapt Hint",
         "altTitle": "Alt Hint title text",
-        "body": "An extension that adds a small, clickable icon to a component that displays additional information."
+        "body": "An extension that adds a small, clickable icon to a component that displays additional information.",
+        "_button": {
+            "_iconClass": "icon-question",
+            "_alignIconRight": true,
+            "text": "Hint",
+            "ariaLabel": ""
+        }
+    }
+
+    // add to globals in course.json
+    "_globals": {
+        "_hint": {
+            "openButtonText": "Open hint"
+        }
     }

--- a/example.json
+++ b/example.json
@@ -9,6 +9,5 @@
                 "title": "Additional",
                 "body": "Information"
             }
-        ],
-        "_isNotifyPopup": false
+        ]
     }

--- a/example.json
+++ b/example.json
@@ -13,7 +13,9 @@
 
     // add to globals in course.json
     "_globals": {
-        "_hint": {
-            "openButtonText": "Open hint"
+        "_extensions": {
+            "_hint": {
+                "openButtonText": "Open hint"
+            }
         }
     }

--- a/example.json
+++ b/example.json
@@ -1,13 +1,5 @@
     // add to component in component.json
     "_hint": {
-        "_items": [
-            {
-                "title": "Adapt Hint",
-                "body": "An extension that adds a small, clickable icon to a component that displays additional information."
-            },
-            {
-                "title": "Additional",
-                "body": "Information"
-            }
-        ]
+        "title": "Adapt Hint",
+        "body": "An extension that adds a small, clickable icon to a component that displays additional information."
     }

--- a/example.json
+++ b/example.json
@@ -1,5 +1,6 @@
     // add to component in component.json
     "_hint": {
         "title": "Adapt Hint",
+        "altTitle": "Alt Hint title text",
         "body": "An extension that adds a small, clickable icon to a component that displays additional information."
     }

--- a/js/adapt-hint.js
+++ b/js/adapt-hint.js
@@ -36,7 +36,7 @@ define([
       const data = this.model.toJSON();
       const template = Handlebars.templates.hint;
 
-      this.$el.html(template(data)).appendTo($('.' + this.model.get('_id')));
+      this.$el.html(template(data)).appendTo($('.' + this.model.get('_id')).find('.component__header-inner'));
 
       _.defer(this.postRender.bind(this));
     },

--- a/js/adapt-hint.js
+++ b/js/adapt-hint.js
@@ -48,9 +48,7 @@ define([
     onHintPopupClicked: function() {
       Adapt.notify.popup({
         _view: new HintPopupView({ model: this.model }),
-        _isCancellable: true,
-        _showCloseButton: true,
-        _closeOnBackdrop: true
+        _classes: 'hint-popup'
       });
     }
 

--- a/js/adapt-hint.js
+++ b/js/adapt-hint.js
@@ -22,7 +22,6 @@ define([
   const HintView = Backbone.View.extend({
 
     events: {
-      'click .js-hint-btn-toggle': 'onHintToggleClicked',
       'click .js-hint-btn-popup': 'onHintPopupClicked'
     },
 
@@ -30,11 +29,6 @@ define([
 
     initialize: function() {
       this.listenTo(Adapt, 'remove', this.remove);
-
-      if (!this.model.get('_hint')._isNotifyPopup) {
-        this.listenTo(Adapt, 'hint:opened', this.checkIfShouldClose);
-      }
-
       this.render();
     },
 
@@ -58,41 +52,6 @@ define([
         _showCloseButton: true,
         _closeOnBackdrop: true
       });
-    },
-
-    onHintToggleClicked: function (e) {
-      const $button = this.$('.js-hint-btn-toggle');
-      const $widget = this.$('.js-hint-widget');
-      const globals = Adapt.course.get('_globals')._extensions._hint;
-      const isBeingOpened = $widget.hasClass('is-closed');
-
-      $widget
-        .toggleClass('is-open', isBeingOpened)
-        .toggleClass('is-closed', !isBeingOpened);
-      $button
-        .toggleClass('is-open', isBeingOpened)
-        .toggleClass('is-closed', !isBeingOpened)
-        .attr('aria-label', (isBeingOpened ? globals.closeButtonText : globals.openButtonText));
-
-      if (isBeingOpened) {
-        Adapt.a11y.popupOpened($widget);
-        Adapt.trigger('hint:opened', this.model.get('_id'));
-        return;
-      }
-
-      Adapt.a11y.popupClosed($button);
-    },
-
-    /**
-     * Handles closing the hint pop-out if another hint was opened
-     * @param {string} id The component id of the hint that triggered this event
-     */
-    checkIfShouldClose: function (id) {
-      if (this.model.get('_id') === id) return;
-
-      if (this.$('.js-hint-btn-toggle').hasClass('is-closed')) return;
-
-      this.onHintToggleClicked();
     }
 
   });

--- a/js/adapt-hint.js
+++ b/js/adapt-hint.js
@@ -57,7 +57,7 @@ define([
   });
 
   Adapt.on('componentView:postRender', function (view) {
-    if (view.model.has('_hint') && view.model.get('_hint')._items.length > 0) {
+    if (view.model.has('_hint')) {
       new HintView({
         model: view.model
       });

--- a/js/adapt-hint.js
+++ b/js/adapt-hint.js
@@ -63,11 +63,12 @@ define([
   });
 
   Adapt.on('componentView:postRender', function (view) {
-    if (view.model.has('_hint')) {
-      new HintView({
-        model: view.model
-      });
-    }
+    const hint = view.model.get('_hint');
+    if (!hint || !hint._isEnabled) return;
+
+    new HintView({
+      model: view.model
+    });
   });
 
 });

--- a/js/adapt-hint.js
+++ b/js/adapt-hint.js
@@ -36,7 +36,15 @@ define([
       const data = this.model.toJSON();
       const template = Handlebars.templates.hint;
 
-      this.$el.html(template(data)).appendTo($('.' + this.model.get('_id')).find('.component__header-inner'));
+      const displayTitle = this.model.get('displayTitle');
+      const body = this.model.get('body');
+      const instruction = this.model.get('instruction');
+
+      if (displayTitle || body || instruction) {
+        this.$el.html(template(data)).appendTo($('.' + this.model.get('_id')).find('.component__header-inner'));
+      } else {
+        this.$el.html(template(data)).appendTo($('.' + this.model.get('_id')).find('.component__widget'));
+      }
 
       _.defer(this.postRender.bind(this));
     },

--- a/less/hint.less
+++ b/less/hint.less
@@ -1,6 +1,4 @@
 .hint {
-  // global hint btn
-  // --------------------------------------------------
   &__btn {
     position: absolute;
     top: 0;
@@ -16,38 +14,12 @@
   &__btn .icon {
     .icon-question;
   }
-
-  &__btn.is-open .icon {
-    .icon-cross;
-  }
-
-  // slide out pop up
-  // --------------------------------------------------
-  &__widget {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 20rem;
-    z-index: 15;
-    opacity: 0;
-
-    .dir-rtl & {
-      right: inherit;
-      left: 0;
-    }
-  }
-
-  &__widget.is-open {
-    opacity: 1;
-  }
 }
 
 // --------------------------------------------------
 // THEME
 // --------------------------------------------------
 .hint {
-  // global hint btn
-  // --------------------------------------------------
   &__btn {
     padding: @icon-padding / 2;
     background-color: @item-color;
@@ -61,38 +33,7 @@
     }
   }
 
-  // widget open/close animation
-  // --------------------------------------------------
-  &__widget {
-    .transform(scale(0,0));
-    .transition(all .5s ease-in-out);
-    transform-origin: top right;
-
-    .dir-rtl & {
-      transform-origin: top left;
-    }
-  }
-
-  &__widget.is-open {
-    .transform(scale(1,1));
-  }
-
-  // slide out pop up
-  // --------------------------------------------------
-  &__widget {
-    top: (@icon-size + @icon-padding) / 2;
-    right: (@icon-size + @icon-padding) / 2;
-    padding: @item-padding;
-    background-color: @white;
-    border: .125rem solid @item-color;
-
-    .dir-rtl & {
-      right: inherit;
-      left: (@icon-size + @icon-padding) / 2;
-    }
-  }
-
-  // slide out item
+  // Pop up item
   // --------------------------------------------------
   &__item:not(:last-child) {
     margin-bottom: @item-margin * 2;

--- a/less/hint.less
+++ b/less/hint.less
@@ -22,23 +22,5 @@
       .transition(background-color @duration ease-in, color @duration ease-in;);
     }
   }
-
-  // Pop up item
-  // --------------------------------------------------
-  &__item:not(:last-child) {
-    margin-bottom: @item-margin * 2;
-  }
-
-  &__item-title {
-    .item-title;
-  }
-
-  &__item-title.has-margin {
-    margin-bottom: @item-title-margin;
-  }
-
-  &__item-body a {
-    .link-text;
-  }
 }
 

--- a/less/hint.less
+++ b/less/hint.less
@@ -1,15 +1,5 @@
 .hint {
-  &__btn {
-    position: absolute;
-    top: 0;
-    right: 0;
-    z-index: 20;
-
-    .dir-rtl & {
-      right: inherit;
-      left: 0;
-    }
-  }
+  &__btn {}
 
   &__btn .icon {
     .icon-question;
@@ -52,15 +42,3 @@
   }
 }
 
-// prevent overlap with first element within the component header
-// --------------------------------------------------
-.component.has-hint .component {
-  &__header-inner > div:first-of-type {
-    padding-right: @icon-size + @icon-padding;
-
-    .dir-rtl & {
-      padding-right: inherit;
-      padding-left: @icon-size + @icon-padding;
-    }
-  }
-}

--- a/less/hint.less
+++ b/less/hint.less
@@ -1,4 +1,6 @@
 .hint {
+  margin-bottom: @btn-margin;
+  
   &__btn {
     display: flex;
     align-items: center;
@@ -13,7 +15,7 @@
 // THEME
 // --------------------------------------------------
 .hint {
-  
+
   // buttons with text and icon (left aligned icon as default)
   // --------------------------------------------------
   &__btn.btn-icon:not(.align-icon-right).btn-text &__btn-icon + &__btn-text {

--- a/less/hint.less
+++ b/less/hint.less
@@ -1,8 +1,11 @@
 .hint {
-  &__btn {}
+  &__btn {
+    display: flex;
+    align-items: center;
+  }
 
-  &__btn .icon {
-    .icon-question;
+  &__btn.align-icon-right {
+    flex-direction: row-reverse;
   }
 }
 
@@ -10,11 +13,32 @@
 // THEME
 // --------------------------------------------------
 .hint {
+  
+  // buttons with text and icon (left aligned icon as default)
+  // --------------------------------------------------
+  &__btn.btn-icon:not(.align-icon-right).btn-text &__btn-icon + &__btn-text {
+    padding-left: (@icon-padding / 2);
+
+    .dir-rtl & {
+      padding-left: 0;
+      padding-right: (@icon-padding / 2);
+    }
+  }
+
+  // buttons with text and icon (right aligned icon)
+  // --------------------------------------------------
+  &__btn.btn-icon.align-icon-right.btn-text &__btn-text {
+    padding-right: (@icon-padding / 2);
+
+    .dir-rtl & {
+      padding-left: (@icon-padding / 2);
+      padding-right: 0;
+    }
+  }
+
   &__btn {
-    padding: @icon-padding / 2;
     background-color: @item-color;
     color: @item-color-inverted;
-    border-radius: 50%;
 
     .no-touch &:hover {
       background-color: @item-color-hover;

--- a/less/hintPopup.less
+++ b/less/hintPopup.less
@@ -1,17 +1,13 @@
 .hint-popup {
-  &__item:not(:last-child) {
-    margin-bottom: @item-margin * 2;
+  &__title {
+    .notify-title;
   }
 
-  &__item-title {
-    .item-title;
-  }
-
-  &__item-title.has-margin {
+  &__title.has-margin {
     margin-bottom: @item-title-margin;
   }
 
-  &__item-body a {
+  &__body a {
     .link-text;
   }
 }

--- a/less/hintPopup.less
+++ b/less/hintPopup.less
@@ -3,8 +3,8 @@
     .notify-title;
   }
 
-  &__title.has-margin {
-    margin-bottom: @item-title-margin;
+  &__title:not(.aria-label) + &__body {
+    margin-top: @item-title-margin;
   }
 
   &__body a {

--- a/less/hintPopup.less
+++ b/less/hintPopup.less
@@ -1,3 +1,6 @@
+// --------------------------------------------------
+// THEME
+// --------------------------------------------------
 .hint-popup {
   &__title {
     .notify-title;
@@ -9,5 +12,11 @@
 
   &__body a {
     .link-text;
+    color: @notify-link;
+
+    .no-touch &:hover {
+      color: @notify-link-hover;
+      .transition(color @duration ease-in);
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "adapt-hint",
+  "version": "3.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "adapt-hint",
+      "version": "3.0.0",
+      "license": "GPL-3.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "adapt-hint",
+  "version": "3.0.0",
+  "framework": ">=5.5",
+  "homepage": "https://github.com/cgkineo/adapt-hint",
+  "bugs": "https://github.com/cgkineo/adapt-hint/issues",
+  "extension": "hint",
+  "displayName": "Hint",
+  "description": "An extension that adds a small icon to any component that, when clicked, displays additional information",
+  "main": "/js/adapt-hint.js",
+  "keywords": [
+    "adapt-plugin",
+    "adapt-extension"
+  ],
+  "license": "GPL-3.0",
+  "targetAttribute": "_hint"
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/cgkineo/adapt-hint/issues",
   "extension": "hint",
   "displayName": "Hint",
-  "description": "An extension that adds a small icon to any component that, when clicked, displays additional information",
+  "description": "An extension that adds a button to any component that, when selected, displays additional information in a popup",
   "main": "/js/adapt-hint.js",
   "keywords": [
     "adapt-plugin",

--- a/properties.schema
+++ b/properties.schema
@@ -6,8 +6,9 @@
   "globals": {
     "openButtonText": {
       "type": "string",
+      "title": "Button ARIA label",
       "required": true,
-      "default": "open hint",
+      "default": "Open hint",
       "inputType": "Text",
       "validators": [],
       "translatable": true
@@ -41,31 +42,77 @@
               "required": false,
               "legend": "Hint",
               "properties": {
-                "_items": {
-                  "type": "array",
+                "title": {
+                  "type": "string",
+                  "required": false,
+                  "default": "",
+                  "title": "Title",
+                  "inputType": "Text",
+                  "validators": [],
+                  "translatable": true,
+                  "help": "Title displayed in the popup"
+                },
+                "altTitle": {
+                  "type": "string",
+                  "required": false,
+                  "default": "",
+                  "title": "Alternative title text",
+                  "inputType": "Text",
+                  "validators": [],
+                  "translatable": true,
+                  "help": "Text read out by screen readers if no visual title is included in the popup",
+                },
+                "body": {
+                  "type": "string",
                   "required": true,
-                  "title": "Hint item(s)",
-                  "items": {
-                    "type": "object",
-                    "required": true,
-                    "title": "Items",
-                    "properties": {
-                      "title": {
-                        "type": "string",
-                        "required": false,
-                        "title": "Title",
-                        "inputType": "Text",
-                        "validators": [],
-                        "translatable": true
-                      },
-                      "body": {
-                        "type": "string",
-                        "required": true,
-                        "title": "Body",
-                        "inputType": "Text",
-                        "validators": [],
-                        "translatable": true
-                      }
+                  "default": "",
+                  "title": "Body",
+                  "inputType": "Text",
+                  "validators": [],
+                  "translatable": true,
+                  "help": "Body text displayed in the popup",
+                },
+                "_button": {
+                  "type": "object",
+                  "required": false,
+                  "title": "Hint button",
+                  "properties": {
+                    "_iconClass": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "title": "Icon class",
+                      "inputType": "Text",
+                      "validators": [],
+                      "help": "Icon that displays on the button. Optional, use with/without text. CSS class name must be pre-defined."
+                    },
+                    "_alignIconRight": {
+                      "type": "boolean",
+                      "required": false,
+                      "default": true,
+                      "title": "Align icon right",
+                      "inputType": "Checkbox",
+                      "validators": [],
+                      "help": "Defines whether the icon is aligned to the left or right of the text."
+                    },
+                    "text": {
+                      "type": "string",
+                      "required": false,
+                      "default": "Hint",
+                      "title": "Button text",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true,
+                      "help": "Text that displays on the button. Optional, use with/without an icon."
+                    },
+                    "ariaLabel": {
+                      "type": "string",
+                      "required": false,
+                      "default": "",
+                      "title": "ARIA label",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
                     }
                   }
                 }

--- a/properties.schema
+++ b/properties.schema
@@ -12,14 +12,6 @@
       "validators": [],
       "translatable": true
     },
-    "closeButtonText": {
-      "type": "string",
-      "required": true,
-      "default": "close hint",
-      "inputType": "Text",
-      "validators": [],
-      "translatable": true
-    },
     "ariaLabelNotify": {
       "type": "string",
       "required": true,
@@ -84,15 +76,6 @@
                       }
                     }
                   }
-                },
-                "_isNotifyPopup": {
-                  "type": "boolean",
-                  "required": false,
-                  "default": false,
-                  "title": "Use Notify popup?",
-                  "inputType": "Checkbox",
-                  "validators": [],
-                  "help": "If enabled, hint popup will display as Adapt Notify popup. Recommended for optimum accessibility support."
                 }
               }
             }

--- a/properties.schema
+++ b/properties.schema
@@ -43,6 +43,13 @@
               "required": false,
               "legend": "Hint",
               "properties": {
+                "_isEnabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "title": "Is enabled",
+                  "help": "Apply hint button to component.",
+                  "inputType": "Checkbox"
+                },
                 "title": {
                   "type": "string",
                   "required": false,
@@ -113,7 +120,8 @@
                       "title": "ARIA label",
                       "inputType": "Text",
                       "validators": [],
-                      "translatable": true
+                      "translatable": true,
+                      "help": "Text read out by screen readers if no visual button text is set."
                     }
                   }
                 }

--- a/properties.schema
+++ b/properties.schema
@@ -11,14 +11,6 @@
       "inputType": "Text",
       "validators": [],
       "translatable": true
-    },
-    "ariaLabelNotify": {
-      "type": "string",
-      "required": true,
-      "default": "Hint",
-      "inputType": "Text",
-      "validators": [],
-      "translatable": true
     }
   },
   "properties": {

--- a/properties.schema
+++ b/properties.schema
@@ -2,6 +2,7 @@
   "type": "object",
   "$schema": "http://json-schema.org/draft-03/schema",
   "id": "http://jsonschema.net",
+  "$ref": "http://localhost/plugins/content/component/model.schema",
   "required": false,
   "globals": {
     "openButtonText": {
@@ -60,7 +61,7 @@
                   "inputType": "Text",
                   "validators": [],
                   "translatable": true,
-                  "help": "Text read out by screen readers if no visual title is included in the popup",
+                  "help": "Text read out by screen readers if no visual title is included in the popup"
                 },
                 "body": {
                   "type": "string",
@@ -70,7 +71,7 @@
                   "inputType": "Text",
                   "validators": [],
                   "translatable": true,
-                  "help": "Body text displayed in the popup",
+                  "help": "Body text displayed in the popup"
                 },
                 "_button": {
                   "type": "object",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -13,6 +13,11 @@
           "title": "Hint",
           "default": {},
           "properties": {
+            "_isEnabled": {
+              "type": "boolean",
+              "title": "Enable Hint button",
+              "default": false
+            },
             "title": {
               "type": "string",
               "title": "Title",
@@ -69,6 +74,7 @@
                 "ariaLabel": {
                   "type": "string",
                   "title": "ARIA label",
+                  "description": "Text read out by screen readers if no visual button text is set.",
                   "default": "",
                   "_adapt": {
                     "translatable": true

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -13,29 +13,28 @@
           "title": "Hint",
           "default": {},
           "properties": {
-            "_items": {
-              "type": "array",
-              "title": "Hint item(s)",
-              "default": [],
-              "items": {
-                "type": "object",
-                "properties": {
-                  "title": {
-                    "type": "string",
-                    "title": "Title",
-                    "default": "",
-                    "_adapt": {
-                      "translatable": true
-                    }
-                  },
-                  "body": {
-                    "type": "string",
-                    "title": "Body",
-                    "_adapt": {
-                      "translatable": true
-                    }
-                  }
-                }
+            "title": {
+              "type": "string",
+              "title": "Title text for the popup",
+              "default": "",
+              "_adapt": {
+                "translatable": true
+              }
+            },
+            "altTitle": {
+              "type": "string",
+              "title": "Alternative title text for the popup",
+              "description": "Text read out by screen readers if no visual title is included",
+              "default": "",
+              "_adapt": {
+                "translatable": true
+              }
+            },
+            "body": {
+              "type": "string",
+              "title": "Body text for the popup",
+              "_adapt": {
+                "translatable": true
               }
             }
           }

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -1,5 +1,5 @@
 {
-  "$anchor": "_hint-component",
+  "$anchor": "hint-component",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "$patch": {

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -15,7 +15,8 @@
           "properties": {
             "title": {
               "type": "string",
-              "title": "Title text for the popup",
+              "title": "Title",
+              "description": "Title displayed in the popup",
               "default": "",
               "_adapt": {
                 "translatable": true
@@ -23,8 +24,8 @@
             },
             "altTitle": {
               "type": "string",
-              "title": "Alternative title text for the popup",
-              "description": "Text read out by screen readers if no visual title is included",
+              "title": "Alternative title text",
+              "description": "Text read out by screen readers if no visual title is included in the popup",
               "default": "",
               "_adapt": {
                 "translatable": true
@@ -32,9 +33,47 @@
             },
             "body": {
               "type": "string",
-              "title": "Body text for the popup",
+              "title": "Body",
+              "description": "Body text displayed in the popup",
+              "default": "",
               "_adapt": {
                 "translatable": true
+              },
+              "_backboneForms": "TextArea"
+            },
+            "_button": {
+              "type": "object",
+              "title": "Hint button",
+              "properties": {
+                "_iconClass": {
+                  "type": "string",
+                  "title": "Icon class",
+                  "description": "Icon that displays on the button. Optional, use with/without text. CSS class name must be pre-defined.",
+                  "default": "icon-question"
+                },
+                "_alignIconRight": {
+                  "type": "boolean",
+                  "title": "Align icon right",
+                  "description": "Defines whether the icon is aligned to the left or right of the text.",
+                  "default": true
+                },
+                "text": {
+                  "type": "string",
+                  "title": "Button text",
+                  "description": "Text that displays on the button. Optional, use with/without an icon.",
+                  "default": "Hint",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "ariaLabel": {
+                  "type": "string",
+                  "title": "ARIA label",
+                  "default": "",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                }
               }
             }
           }

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -37,12 +37,6 @@
                   }
                 }
               }
-            },
-            "_isNotifyPopup": {
-              "type": "boolean",
-              "title": "Use Notify popup?",
-              "description": "If enabled, hint popup will display as Adapt Notify popup. Recommended for optimum accessibility support.",
-              "default": false
             }
           }
         }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -28,14 +28,6 @@
                       "_adapt": {
                         "translatable": true
                       }
-                    },
-                    "ariaLabelNotify": {
-                      "type": "string",
-                      "title": "Aria label notify",
-                      "default": "Hint",
-                      "_adapt": {
-                        "translatable": true
-                      }
                     }
                   }
                 }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -1,5 +1,5 @@
 {
-  "$anchor": "_hint-course",
+  "$anchor": "hint-course",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "$patch": {

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -29,14 +29,6 @@
                         "translatable": true
                       }
                     },
-                    "closeButtonText": {
-                      "type": "string",
-                      "title": "Close button text",
-                      "default": "close hint",
-                      "_adapt": {
-                        "translatable": true
-                      }
-                    },
                     "ariaLabelNotify": {
                       "type": "string",
                       "title": "Aria label notify",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -23,8 +23,8 @@
                   "properties": {
                     "openButtonText": {
                       "type": "string",
-                      "title": "Open button text",
-                      "default": "open hint",
+                      "title": "Button ARIA label",
+                      "default": "Open hint",
                       "_adapt": {
                         "translatable": true
                       }

--- a/templates/hint.hbs
+++ b/templates/hint.hbs
@@ -1,4 +1,4 @@
-<div class="hint__inner js-hint-inner">
+<div class="hint__inner">
 
   <button class="btn-icon hint__btn js-hint-btn-popup"
     aria-label="{{_globals._extensions._hint.openButtonText}}">

--- a/templates/hint.hbs
+++ b/templates/hint.hbs
@@ -1,38 +1,8 @@
 <div class="hint__inner js-hint-inner">
 
-  <button class="btn-icon hint__btn{{#if _hint._isNotifyPopup}} js-hint-btn-popup{{else}} js-hint-btn-toggle{{/if}} is-closed"
+  <button class="btn-icon hint__btn js-hint-btn-popup"
     aria-label="{{_globals._extensions._hint.openButtonText}}">
     <div class="icon"></div>
   </button>
-
-  {{#unless _hint._isNotifyPopup}}
-  <div class="hint__widget js-hint-widget is-closed" role="complementary">
-
-    {{#each _hint._items}}
-    <div class="hint__item item-{{@index}}">
-      <div class="hint__item-inner">
-
-        {{#if title}}
-        <div class="hint__item-title{{#if body}} has-margin{{/if}}">
-          <div class="hint__item-title-inner">
-            {{{compile title}}}
-          </div>
-        </div>
-        {{/if}}
-
-        {{#if body}}
-        <div class="hint__item-body">
-          <div class="hint__item-body-inner">
-            {{{compile body}}}
-          </div>
-        </div>
-        {{/if}}
-
-      </div>
-    </div>
-    {{/each}}
-
-  </div>
-  {{/unless}}
 
 </div>

--- a/templates/hint.hbs
+++ b/templates/hint.hbs
@@ -1,8 +1,28 @@
 <div class="hint__inner">
 
-  <button class="btn-icon hint__btn js-hint-btn-popup"
-    aria-label="{{_globals._extensions._hint.openButtonText}}">
-    <div class="icon"></div>
+  <button class="hint__btn {{#if _hint._button._iconClass}} btn-icon{{/if}}{{#if _hint._button._alignIconRight}} align-icon-right{{/if}}{{#if _hint._button.text}} btn-text{{/if}} js-hint-btn-popup"
+  {{#unless _hint._button.text}}
+  {{#if _hint._button.ariaLabel}}
+   aria-label="{{_hint._button.ariaLabel}}"
+  {{else}}
+   aria-label="{{_globals._extensions._hint.openButtonText}}"
+  {{/if}}
+  {{/unless}}>
+    
+    {{#if _hint._button._iconClass}}
+    <span class="hint__btn-icon">
+      <span class="icon {{_hint._button._iconClass}}" aria-hidden="true"></span>
+    </span>
+    {{/if}}
+
+    {{#if _hint._button.text}}
+    <span class="hint__btn-text">
+      <span class="hint__btn-text-inner">
+        {{{_hint._button.text}}}
+      </span>
+    </span>
+    {{/if}}
+
   </button>
 
 </div>

--- a/templates/hintPopup.hbs
+++ b/templates/hintPopup.hbs
@@ -2,28 +2,26 @@
 
   <div id="notify-heading" class="aria-label">{{{_globals._extensions._hint.ariaLabelNotify}}}</div>
 
-  {{#each _hint._items}}
-  <div class="hint-popup__item item-{{@index}}">
-    <div class="hint-popup__item-inner">
+  <div class="hint-popup__content">
+    <div class="hint-popup__content-inner">
 
-      {{#if title}}
-      <div class="hint-popup__item-title{{#if body}} has-margin{{/if}}">
-        <div class="hint-popup__item-title-inner">
-          {{{compile title}}}
+      {{#if _hint.title}}
+      <div class="hint-popup__title{{#if body}} has-margin{{/if}}">
+        <div class="hint-popup__title-inner">
+          {{{compile _hint.title}}}
         </div>
       </div>
       {{/if}}
 
-      {{#if body}}
-      <div class="hint-popup__item-body">
-        <div class="hint-popup__item-body-inner">
-          {{{compile body}}}
+      {{#if _hint.body}}
+      <div class="hint-popup__body">
+        <div class="hint-popup__body-inner">
+          {{{compile _hint.body}}}
         </div>
       </div>
       {{/if}}
 
     </div>
   </div>
-  {{/each}}
 
 </div>

--- a/templates/hintPopup.hbs
+++ b/templates/hintPopup.hbs
@@ -1,14 +1,18 @@
 <div class="hint-popup__inner">
 
-  <div id="notify-heading" class="aria-label">{{{_globals._extensions._hint.ariaLabelNotify}}}</div>
-
   <div class="hint-popup__content">
     <div class="hint-popup__content-inner">
 
       {{#if _hint.title}}
-      <div class="hint-popup__title{{#if body}} has-margin{{/if}}">
-        <div class="hint-popup__title-inner">
+      <div class="hint-popup__title{{#if body}} has-margin{{/if}}" id="notify-heading">
+        <div class="hint-popup__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
           {{{compile _hint.title}}}
+        </div>
+      </div>
+      {{else if _hint.altTitle}}
+      <div class="hint-popup__title aria-label" id="notify-heading">
+        <div class="hint-popup__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
+          {{{compile _hint.altTitle}}}
         </div>
       </div>
       {{/if}}

--- a/templates/hintPopup.hbs
+++ b/templates/hintPopup.hbs
@@ -4,7 +4,7 @@
     <div class="hint-popup__content-inner">
 
       {{#if _hint.title}}
-      <div class="hint-popup__title{{#if body}} has-margin{{/if}}" id="notify-heading">
+      <div class="hint-popup__title" id="notify-heading">
         <div class="hint-popup__title-inner" role="heading" aria-level="{{a11y_aria_level _id 'notify' _ariaLevel}}">
           {{{compile _hint.title}}}
         </div>


### PR DESCRIPTION
This PR addresses the following tasks raised in issue #13:


**1. Switch to notify only with text + graphic in schema**
- native popup removed and notify popup made default
- a11y titles (`title` and `altTitle`) setup as per notify
Fixes https://github.com/cgkineo/adapt-hint/issues/14 (now consistent with notify a11y titles, item titles void as these have been removed)
- _notify graphic support still outstanding - raised as a separate issue to gain further input https://github.com/cgkineo/adapt-hint/issues/16_ 

**2. Position under component header and before widget**
- append the Hint button between the component display text and the widget to suite the typical use case
- remove the absolute position so the button display matches the DOM order (WCAG C27: Making the DOM order match the visual order)
Fixes https://github.com/cgkineo/adapt-hint/issues/7 
Fixes https://github.com/cgkineo/adapt-hint/issues/6 (button is no longer a direct child of component so issue is void)


**3. Allow button text +/ icon**
- make icon class configurable
- make icon alignment configurable
- add component level text and ariaLabel (as well as existing global aria)
- remove button border-radius and padding styles as these are inherited from `.btn-icon` and `.btn-text` selectors
- new properties and globals added to example


**4. remove items (only single title and body are used)**
- on reviewing use case, only single title and body are used per hint (multiple items aren't being used)
- title inherits notify title style
- replace `.hint-popup__item` with `.hint-popup__content` containers for consistency with other notify popups (hotgraphic and tutor)

Fixes https://github.com/cgkineo/adapt-hint/issues/13

# Testing PR
Apply the following config to any component. Typical use cases are:
- 'hints' for question components (providing additional content to aid a user in answering a question)
- 'more info' for presentation components (to stash away text heavy content, or, content of a particular type/theme)

```
    "_hint": {
        "title": "Adapt Hint",
        "altTitle": "Alt Hint title text",
        "body": "An extension that adds a small, clickable icon to a component that displays additional information.",
        "_button": {
            "_iconClass": "icon-question",
            "_alignIconRight": true,
            "text": "Hint",
            "ariaLabel": ""
        }
    }
```
And the globals in course.json:
```
    "_globals": {
        "_hint": {
            "openButtonText": "Open hint"
        }
    }
```

# Notes
- I have a11y tested this with VoiceOver on Mac
- needs AAT testing
- README demo.gif needs replacing to reflect new functionality/display.

