### PR TITLE
New: Added support for new Vanilla button color mixins (fixes #32)

### DIFF
--- a/less/hint.less
+++ b/less/hint.less
@@ -41,7 +41,8 @@
     }
   }
 
-  &__btn {
+  &__btn.btn-icon,
+  &__btn.btn-text {
     // apply legacy styles if Vanilla button styles aren't supported
     & when (@item-ui-color-style = none) {
       background-color: @item-color;

--- a/less/hint.less
+++ b/less/hint.less
@@ -14,6 +14,9 @@
 // --------------------------------------------------
 // THEME
 // --------------------------------------------------
+// @item-ui-color-style fallback if Vanilla button styles aren't supported
+@item-ui-color-style: none;
+
 .hint {
 
   // buttons with text and icon (left aligned icon as default)
@@ -39,6 +42,18 @@
   }
 
   &__btn {
+    // apply legacy styles if Vanilla button styles aren't supported
+    & when (@item-ui-color-style = none) {
+      background-color: @item-color;
+      color: @item-color-inverted;
+  
+      .no-touch &:hover {
+        background-color: @item-color-hover;
+        color: @item-color-inverted-hover;
+        .transition(background-color @duration ease-in, color @duration ease-in;);
+      }
+    }
+    
     & when (@item-ui-color-style = filled) {
       .item-ui-color;
   

--- a/less/hint.less
+++ b/less/hint.less
@@ -39,13 +39,28 @@
   }
 
   &__btn {
-    background-color: @item-color;
-    color: @item-color-inverted;
+    & when (@item-ui-color-style = filled) {
+      .item-ui-color;
+  
+      .no-touch &:hover {
+        .item-ui-color-hover;
+      }
 
-    .no-touch &:hover {
-      background-color: @item-color-hover;
-      color: @item-color-inverted-hover;
-      .transition(background-color @duration ease-in, color @duration ease-in;);
+      html:not(.a11y-disable-focusoutline) &:focus-visible {
+        .item-ui-color-focus;
+      }
+    }
+
+    & when (@item-ui-color-style = outline) {
+      .item-ui-color-outline;
+  
+      .no-touch &:hover {
+        .item-ui-color-outline-hover;
+      }
+
+      html:not(.a11y-disable-focusoutline) &:focus-visible {
+        .item-ui-color-outline-focus;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-hint/issues/32

### New
* Added support for new [Vanilla button color mixins PR](https://github.com/adaptlearning/adapt-contrib-vanilla/pull/490 ). Default button style set to `filled` to mimic current Vanilla and `outline` as optional style. The implementation allows for additional styles to be created for custom themes.
* Focus state added.
* Legacy support added to prevent breaking change.
* Button selector classes extended to prevent Vanilla styles overwriting (generic .`btn-text` and `.btn-icon` styles in Vanilla [button.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/64ac2c3e95d585de367d38ba00ddf11e2b0b06a7/less/core/button.less#L16C30-L16C62)). Same issue applies to Hint master, this wasn't introduced during this PR.

### Testing legacy support
1. Install Vanilla master.
2. There should be no change in styling. Legacy styles apply.

### Testing new Vanilla buttons
1. Install Vanilla [PR](https://github.com/adaptlearning/adapt-contrib-vanilla/tree/issue/469).
2. Hint button style can be changed via the `@item-ui-color-style` variable in [less/_defaults/_btn-style.less](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/issue/469/less/_defaults/_btn-style.less). Test both `filled` and `outline` styles.
3. Check all states styles apply (default, hover and focus).
