### PR TITLE
New: Add _classes property to button (fix #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ The attributes listed below are used in *components.json* to configure **Hint**,
 
 >**body** (string): The body text displayed in the popup.
 
->**\_classes** (string):
-CSS class name(s) to be applied to the `button`. The class must be predefined in one of the Less files. Separate multiple classes with a space.
-
 >**\_imageAlignment** (string):
 Defines the alignment of the popup image. Left: Image aligned to the left of the text area. Top: Image aligned above the text area. Right: Image aligned to the right of the text area. Bottom: Image aligned below the text area. The default alignment is `right`.
 
@@ -49,6 +46,9 @@ The alternative text for this image. Assign [alt text](https://github.com/adaptl
 Optional text to be displayed as an [attribution](https://wiki.creativecommons.org/Best_practices_for_attribution). By default it is displayed below the image. Adjust positioning by modifying CSS. Text can contain HTML tags, e.g., `Copyright © 2015 by <b>Lukasz 'Severiaan' Grela</b>`.
 
 >**\_button** (object): The **Hint** button contains values for **\_iconClass**, **\_alignIconRight**, **text** and **ariaLabel**.
+
+>>**\_classes** (string):
+CSS class name(s) to be applied to the `button`. The class must be predefined in one of the Less files. Separate multiple classes with a space.
 
 >>**\_iconClass** (string): CSS class name to be applied to the `button` icon. The class must be predefined in one of the Less files with the corresponding icon added as part of a font. See list of available [_vanilla_ icons](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Icons) to choose from. Default is `icon-question`.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ The attributes listed below are used in *components.json* to configure **Hint**,
 
 >**body** (string): The body text displayed in the popup.
 
+>**\_classes** (string):
+CSS class name(s) to be applied to the `button`. The class must be predefined in one of the Less files. Separate multiple classes with a space.
+
 >**\_imageAlignment** (string):
 Defines the alignment of the popup image. Left: Image aligned to the left of the text area. Top: Image aligned above the text area. Right: Image aligned to the right of the text area. Bottom: Image aligned below the text area. The default alignment is `right`.
 

--- a/example.json
+++ b/example.json
@@ -4,6 +4,7 @@
         "title": "Adapt Hint",
         "altTitle": "Alt Hint title text",
         "body": "An extension that adds a small, clickable icon to a component that displays additional information.",
+        "_classes": "",
         "_imageAlignment": "right",
         "_graphic": {
             "_src": "course/en/images/example.jpg",

--- a/example.json
+++ b/example.json
@@ -4,7 +4,6 @@
         "title": "Adapt Hint",
         "altTitle": "Alt Hint title text",
         "body": "An extension that adds a small, clickable icon to a component that displays additional information.",
-        "_classes": "",
         "_imageAlignment": "right",
         "_graphic": {
             "_src": "course/en/images/example.jpg",
@@ -12,6 +11,7 @@
             "attribution": ""
         },
         "_button": {
+            "_classes": "",
             "_iconClass": "icon-question",
             "_alignIconRight": true,
             "text": "Hint",

--- a/properties.schema
+++ b/properties.schema
@@ -80,6 +80,15 @@
                   "translatable": true,
                   "help": "Body text displayed in the popup"
                 },
+                "_classes": {
+                  "type": "string",
+                  "default": "",
+                  "isSetting": true,
+                  "inputType": "Text",
+                  "validators": [ ],
+                  "title": "Classes",
+                  "help": "Used to style or manipulate the look and feel of the Hint item. These are predefined in the theme or added in Project Settings > Custom CSS/Less code."
+                },
                 "_imageAlignment": {
                   "type": "string",
                   "required": false,

--- a/properties.schema
+++ b/properties.schema
@@ -133,7 +133,7 @@
                       "inputType": "Text",
                       "validators": [ ],
                       "title": "Classes",
-                      "help": "Used to style or manipulate the look and feel of the Hint item. These are predefined in the theme or added in Project Settings > Custom CSS/Less code."
+                      "help": "Used to style or manipulate the look and feel of the Hint button. These are predefined in the theme or added in Project Settings > Custom CSS/Less code."
                     },
                     "_iconClass": {
                       "type": "string",

--- a/properties.schema
+++ b/properties.schema
@@ -80,15 +80,6 @@
                   "translatable": true,
                   "help": "Body text displayed in the popup"
                 },
-                "_classes": {
-                  "type": "string",
-                  "default": "",
-                  "isSetting": true,
-                  "inputType": "Text",
-                  "validators": [ ],
-                  "title": "Classes",
-                  "help": "Used to style or manipulate the look and feel of the Hint item. These are predefined in the theme or added in Project Settings > Custom CSS/Less code."
-                },
                 "_imageAlignment": {
                   "type": "string",
                   "required": false,
@@ -135,6 +126,15 @@
                   "required": false,
                   "title": "Hint button",
                   "properties": {
+                    "_classes": {
+                      "type": "string",
+                      "default": "",
+                      "isSetting": true,
+                      "inputType": "Text",
+                      "validators": [ ],
+                      "title": "Classes",
+                      "help": "Used to style or manipulate the look and feel of the Hint item. These are predefined in the theme or added in Project Settings > Custom CSS/Less code."
+                    },
                     "_iconClass": {
                       "type": "string",
                       "required": false,

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -46,6 +46,15 @@
               },
               "_backboneForms": "TextArea"
             },
+            "_classes": {
+              "type": "string",
+              "title": "Classes",
+              "description": "Used to style or manipulate the look and feel of the Hint item. These are predefined in the theme or added in Project Settings > Custom CSS/Less code.",
+              "default": "",
+              "_adapt": {
+                "isSetting": true
+              }
+            },
             "_imageAlignment": {
               "type": "string",
               "title": "Image alignment",

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -101,7 +101,7 @@
                 "_classes": {
                   "type": "string",
                   "title": "Classes",
-                  "description": "Used to style or manipulate the look and feel of the Hint item. These are predefined in the theme or added in Project Settings > Custom CSS/Less code.",
+                  "description": "Used to style or manipulate the look and feel of the Hint button. These are predefined in the theme or added in Project Settings > Custom CSS/Less code.",
                   "default": "",
                   "_adapt": {
                     "isSetting": true

--- a/schema/component.schema.json
+++ b/schema/component.schema.json
@@ -46,15 +46,6 @@
               },
               "_backboneForms": "TextArea"
             },
-            "_classes": {
-              "type": "string",
-              "title": "Classes",
-              "description": "Used to style or manipulate the look and feel of the Hint item. These are predefined in the theme or added in Project Settings > Custom CSS/Less code.",
-              "default": "",
-              "_adapt": {
-                "isSetting": true
-              }
-            },
             "_imageAlignment": {
               "type": "string",
               "title": "Image alignment",
@@ -107,6 +98,15 @@
               "type": "object",
               "title": "Hint button",
               "properties": {
+                "_classes": {
+                  "type": "string",
+                  "title": "Classes",
+                  "description": "Used to style or manipulate the look and feel of the Hint item. These are predefined in the theme or added in Project Settings > Custom CSS/Less code.",
+                  "default": "",
+                  "_adapt": {
+                    "isSetting": true
+                  }
+                },
                 "_iconClass": {
                   "type": "string",
                   "title": "Icon class",

--- a/templates/hint.jsx
+++ b/templates/hint.jsx
@@ -7,11 +7,11 @@ export default function Hint (props) {
     _hint
   } = props;
 
-  const hintButton = _hint._button;
-  const buttonAriaLabel = hintButton.text
+  const button = _hint._button;
+  const buttonAriaLabel = button.text
     ? null
-    : hintButton.ariaLabel
-      ? hintButton.ariaLabel
+    : button.ariaLabel
+      ? button.ariaLabel
       : _globals._extensions._hint.openButtonText;
 
   return (
@@ -21,27 +21,27 @@ export default function Hint (props) {
         className={classes([
           'hint__btn',
           'js-hint-btn-popup',
-          hintButton._iconClass && 'btn-icon',
-          hintButton._alignIconRight && 'align-icon-right',
-          hintButton.text && 'btn-text',
-          hintButton._classes
+          button._iconClass && 'btn-icon',
+          button._alignIconRight && 'align-icon-right',
+          button.text && 'btn-text',
+          button._classes
         ])}
         aria-label={buttonAriaLabel}
       >
 
-        {hintButton._iconClass &&
+        {button._iconClass &&
         <span className='hint__btn-icon'>
           <span
-            className={`icon ${hintButton._iconClass}`}
+            className={`icon ${button._iconClass}`}
             aria-hidden='true'
           ></span>
         </span>
         }
 
-        {hintButton.text &&
+        {button.text &&
         <span className='hint__btn-text'>
           <span className='hint__btn-text-inner'>
-            {compile(hintButton.text)}
+            {compile(button.text)}
           </span>
         </span>
         }

--- a/templates/hint.jsx
+++ b/templates/hint.jsx
@@ -22,7 +22,8 @@ export default function Hint (props) {
           'js-hint-btn-popup',
           _hint._button._iconClass && 'btn-icon',
           _hint._button._alignIconRight && 'align-icon-right',
-          _hint._button.text && 'btn-text'
+          _hint._button.text && 'btn-text',
+          _hint._classes
         ])}
         aria-label={buttonAriaLabel}
       >

--- a/templates/hint.jsx
+++ b/templates/hint.jsx
@@ -23,7 +23,7 @@ export default function Hint (props) {
           _hint._button._iconClass && 'btn-icon',
           _hint._button._alignIconRight && 'align-icon-right',
           _hint._button.text && 'btn-text',
-          _hint._classes
+          _hint._button._classes
         ])}
         aria-label={buttonAriaLabel}
       >

--- a/templates/hint.jsx
+++ b/templates/hint.jsx
@@ -7,10 +7,11 @@ export default function Hint (props) {
     _hint
   } = props;
 
-  const buttonAriaLabel = _hint._button.text
+  const hintButton = _hint._button;
+  const buttonAriaLabel = hintButton.text
     ? null
-    : _hint._button.ariaLabel
-      ? _hint._button.ariaLabel
+    : hintButton.ariaLabel
+      ? hintButton.ariaLabel
       : _globals._extensions._hint.openButtonText;
 
   return (
@@ -20,27 +21,27 @@ export default function Hint (props) {
         className={classes([
           'hint__btn',
           'js-hint-btn-popup',
-          _hint._button._iconClass && 'btn-icon',
-          _hint._button._alignIconRight && 'align-icon-right',
-          _hint._button.text && 'btn-text',
-          _hint._button._classes
+          hintButton._iconClass && 'btn-icon',
+          hintButton._alignIconRight && 'align-icon-right',
+          hintButton.text && 'btn-text',
+          hintButton._classes
         ])}
         aria-label={buttonAriaLabel}
       >
 
-        {_hint._button._iconClass &&
+        {hintButton._iconClass &&
         <span className='hint__btn-icon'>
           <span
-            className={`icon ${_hint._button._iconClass}`}
+            className={`icon ${hintButton._iconClass}`}
             aria-hidden='true'
           ></span>
         </span>
         }
 
-        {_hint._button.text &&
+        {hintButton.text &&
         <span className='hint__btn-text'>
           <span className='hint__btn-text-inner'>
-            {compile(_hint._button.text)}
+            {compile(hintButton.text)}
           </span>
         </span>
         }

--- a/templates/hint.jsx
+++ b/templates/hint.jsx
@@ -40,9 +40,10 @@ export default function Hint (props) {
 
         {button.text &&
         <span className='hint__btn-text'>
-          <span className='hint__btn-text-inner'>
-            {compile(button.text)}
-          </span>
+          <span
+            className='hint__btn-text-inner' 
+            dangerouslySetInnerHTML={{ __html: compile(button.text, props) }}
+          />
         </span>
         }
 


### PR DESCRIPTION
Fix #37 

### New
* Adds `_classes` property to add CSS classes to the `button` element.

### Fix
* Move button text to dangerouslySetInnerHTML